### PR TITLE
Deploy latest AlloraConsumer version to Arbitrum

### DIFF
--- a/deploy/deployments/arbitrum.json
+++ b/deploy/deployments/arbitrum.json
@@ -1,3 +1,1 @@
-{
-    "AlloraConsumer": "0x6032f0862A2c36D0390c348EeCc2ACcDccDa785a"
-}
+{"AlloraConsumer":"0xd75A47C0e5Eb0CeDF57072268F48ba971d2cD7F3"}


### PR DESCRIPTION
Related:
- Docs PR for using the latest consumer contract URL on Arbitrum: https://github.com/allora-network/docs/pull/31